### PR TITLE
Add clickable deck and hand

### DIFF
--- a/Deck.gd
+++ b/Deck.gd
@@ -1,0 +1,25 @@
+extends Node2D
+
+var cards = []
+var hand
+var deck_rect = Rect2(Vector2.ZERO, Vector2(80, 120))
+
+func _ready():
+    for i in range(1, 6):
+        cards.append("Card %d" % i)
+    update()
+
+func _draw():
+    draw_rect(deck_rect, Color(0, 0.5, 0))
+
+func _input(event):
+    if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+        var pos = to_local(event.position)
+        if deck_rect.has_point(pos):
+            draw_card()
+
+func draw_card():
+    if cards.size() > 0 and hand:
+        var card = cards.pop_back()
+        hand.add_card(card)
+        update()

--- a/Hand.gd
+++ b/Hand.gd
@@ -1,0 +1,10 @@
+extends Node2D
+
+var cards = []
+
+func add_card(card):
+    cards.append(card)
+    var label = Label.new()
+    label.text = str(card)
+    label.position = Vector2(100 * (cards.size() - 1), 0)
+    add_child(label)

--- a/Main.gd
+++ b/Main.gd
@@ -1,0 +1,14 @@
+extends Node2D
+
+var deck
+var hand
+
+func _ready():
+    hand = Hand.new()
+    add_child(hand)
+    hand.position = Vector2(200, 300)
+
+    deck = Deck.new()
+    add_child(deck)
+    deck.position = Vector2(100, 100)
+    deck.hand = hand

--- a/main.tscn
+++ b/main.tscn
@@ -1,3 +1,6 @@
-[gd_scene format=3 uid="uid://blakp81nf8w4j"]
+[gd_scene load_steps=2 format=3 uid="uid://blakp81nf8w4j"]
+
+[ext_resource path="res://Main.gd" type="Script" id="1"]
 
 [node name="Main" type="Node2D"]
+script = ExtResource("1")


### PR DESCRIPTION
## Summary
- add `Main.gd` with runtime setup for deck and hand
- implement `Deck.gd` and `Hand.gd` to manage drawing cards
- hook `Main.gd` to scene

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68715cbf304883299f407f4482adc3e4