### PR TITLE
Add GitHub Action for Godot build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Godot Build Check
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Godot 4.4 stable
+        run: |
+          wget -q https://github.com/godotengine/godot-builds/releases/download/4.4-stable/Godot_v4.4-stable_linux.x86_64.zip
+          unzip -q Godot_v4.4-stable_linux.x86_64.zip
+          mv Godot_v4.4-stable_linux.x86_64 godot
+          chmod +x godot
+
+      - name: Check project builds
+        run: |
+          ./godot --headless --check-only --path .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+
+# Local Godot download
+Godot_v4.4-stable_linux.x86_64.zip


### PR DESCRIPTION
## Summary
- add workflow to download Godot 4.4 stable and run a build check
- ignore locally downloaded Godot binary

## Testing
- `wget https://github.com/godotengine/godot-builds/releases/download/4.4-stable/Godot_v4.4-stable_linux.x86_64.zip -O /tmp/godot.zip`
- `unzip -q /tmp/godot.zip -d /tmp`
- `/tmp/Godot_v4.4-stable_linux.x86_64 --headless --check-only --path .` *(fails: Unrecognized UID)*

------
https://chatgpt.com/codex/tasks/task_e_687160820fe0832999ddb31f0a92da32