### PR TITLE
Add Battlefield scene

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+var battlefield_scene := preload("res://scenes/Battlefield.tscn")
+
+func _ready():
+    var battlefield = battlefield_scene.instantiate()
+    add_child(battlefield)

--- a/main.tscn
+++ b/main.tscn
@@ -1,3 +1,6 @@
 [gd_scene format=3 uid="uid://blakp81nf8w4j"]
 
+[ext_resource path="res://main.gd" type="Script" id=1]
+
 [node name="Main" type="Node2D"]
+script = ExtResource(1)

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="TCGGame"
-run/main_scene="uid://blakp81nf8w4j"
+run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 

--- a/scenes/Battlefield.gd
+++ b/scenes/Battlefield.gd
@@ -1,0 +1,22 @@
+extends Node2D
+
+@export var grid_size: Vector2i = Vector2i(7, 7)
+@export var cell_size: Vector2 = Vector2(64, 64)
+
+func _ready():
+    queue_redraw()
+
+func _draw():
+    var width = grid_size.x
+    var height = grid_size.y
+    var w = width * cell_size.x
+    var h = height * cell_size.y
+    var color = Color(1, 1, 1)
+    for x in range(width + 1):
+        var start = Vector2(x * cell_size.x, 0)
+        var end = Vector2(x * cell_size.x, h)
+        draw_line(start, end, color)
+    for y in range(height + 1):
+        var start = Vector2(0, y * cell_size.y)
+        var end = Vector2(w, y * cell_size.y)
+        draw_line(start, end, color)

--- a/scenes/Battlefield.tscn
+++ b/scenes/Battlefield.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[ext_resource path="res://scenes/Battlefield.gd" type="Script" id=1]
+
+[node name="Battlefield" type="Node2D"]
+script = ExtResource(1)


### PR DESCRIPTION
## Summary
- create a Battlefield scene that draws a configurable grid (default 7x7)
- attach Battlefield to the Main scene using a new script
- update project settings to reference `main.tscn`

## Testing
- `godot --headless --quit`

------
https://chatgpt.com/codex/tasks/task_e_687168299c2c8329a21f1335c6bd43bd