### PR TITLE
Add basic tile scenes

### DIFF
--- a/Scenes/Tiles/Forest.tscn
+++ b/Scenes/Tiles/Forest.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2 format=3 uid="uid://forest"]
+
+[ext_resource path="res://Scenes/Tiles/Tile.tscn" type="PackedScene" id=1]
+
+[node name="Forest" instance=ExtResource(1)]

--- a/Scenes/Tiles/River.tscn
+++ b/Scenes/Tiles/River.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2 format=3 uid="uid://river"]
+
+[ext_resource path="res://Scenes/Tiles/Tile.tscn" type="PackedScene" id=1]
+
+[node name="River" instance=ExtResource(1)]

--- a/Scenes/Tiles/Tile.tscn
+++ b/Scenes/Tiles/Tile.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://tile"]
+
+[node name="Tile" type="Node2D"]

--- a/Scenes/Tiles/Village.tscn
+++ b/Scenes/Tiles/Village.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2 format=3 uid="uid://village"]
+
+[ext_resource path="res://Scenes/Tiles/Tile.tscn" type="PackedScene" id=1]
+
+[node name="Village" instance=ExtResource(1)]


### PR DESCRIPTION
## Summary
- add base `Tile` scene
- create `River`, `Forest` and `Village` scenes inheriting from `Tile`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68716889b7b0832989053b420aa2008f