### PR TITLE
Add tile build menu on empty grid click

### DIFF
--- a/Scenes/Battlefield.gd
+++ b/Scenes/Battlefield.gd
@@ -3,8 +3,26 @@ extends Node2D
 @export var grid_size: Vector2i = Vector2i(7, 7)
 @export var cell_size: Vector2 = Vector2(64, 64)
 
+var tile_scenes := {
+    "Forest": preload("res://Scenes/Tiles/Forest.tscn"),
+    "River": preload("res://Scenes/Tiles/River.tscn"),
+    "Village": preload("res://Scenes/Tiles/Village.tscn"),
+}
+
+var tiles: Array = []
+var selected_cell: Vector2i = Vector2i(-1, -1)
+
+@onready var build_menu := $BuildMenu
+
 func _ready():
     queue_redraw()
+    tiles.resize(grid_size.y)
+    for y in range(grid_size.y):
+        tiles[y] = []
+        tiles[y].resize(grid_size.x)
+    for name in tile_scenes.keys():
+        build_menu.add_item(name)
+    build_menu.connect("id_pressed", _on_build_menu_id_pressed)
 
 func _draw():
     var width = grid_size.x
@@ -20,3 +38,24 @@ func _draw():
         var start = Vector2(0, y * cell_size.y)
         var end = Vector2(w, y * cell_size.y)
         draw_line(start, end, color)
+
+func _input(event):
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        var pos = event.position
+        var cell = Vector2i(int(pos.x / cell_size.x), int(pos.y / cell_size.y))
+        if cell.x < 0 or cell.y < 0 or cell.x >= grid_size.x or cell.y >= grid_size.y:
+            return
+        if tiles[cell.y][cell.x] == null:
+            selected_cell = cell
+            build_menu.position = pos
+            build_menu.popup()
+
+func _on_build_menu_id_pressed(id):
+    var name = build_menu.get_item_text(id)
+    if not tile_scenes.has(name):
+        return
+    var scene = tile_scenes[name]
+    var tile = scene.instantiate()
+    add_child(tile)
+    tile.position = Vector2(selected_cell.x, selected_cell.y) * cell_size
+    tiles[selected_cell.y][selected_cell.x] = tile

--- a/Scenes/Battlefield.tscn
+++ b/Scenes/Battlefield.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=0 format=3]
+[gd_scene load_steps=2 format=3]
 
 [ext_resource type="Script" uid="uid://bgtu0dxjkplu" path="res://Scenes/Battlefield.gd" id="1"]
 
 [node name="Battlefield" type="Node2D"]
 script = ExtResource(1)
+
+[node name="BuildMenu" type="PopupMenu" parent="."]


### PR DESCRIPTION
## Summary
- add simple build menu to Battlefield scene
- populate menu with available tiles
- spawn selected tile at clicked cell

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68716b126ef48329b3765c43650a143d