### PR TITLE
Enable right click camera drag

### DIFF
--- a/Scenes/Battlefield.tscn
+++ b/Scenes/Battlefield.tscn
@@ -1,6 +1,11 @@
 [gd_scene load_steps=0 format=3]
 
 [ext_resource type="Script" uid="uid://bgtu0dxjkplu" path="res://Scenes/Battlefield.gd" id="1"]
+[ext_resource type="Script" path="res://Scenes/CameraDrag.gd" id="2"]
 
 [node name="Battlefield" type="Node2D"]
 script = ExtResource(1)
+
+[node name="Camera2D" type="Camera2D" parent="."]
+script = ExtResource(2)
+current = true

--- a/Scenes/CameraDrag.gd
+++ b/Scenes/CameraDrag.gd
@@ -1,0 +1,13 @@
+extends Camera2D
+
+var dragging := false
+
+func _input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT:
+        if event.pressed:
+            dragging = true
+        else:
+            dragging = false
+    elif event is InputEventMouseMotion and dragging:
+        position -= event.relative
+


### PR DESCRIPTION
## Summary
- create `CameraDrag.gd` to allow right mouse dragging
- add a `Camera2D` to `Battlefield.tscn` using the new script

## Testing
- `godot --headless --quit --path . -q`

------
https://chatgpt.com/codex/tasks/task_e_68716b2fc2b483299dffc0a9024d26b4