### PR TITLE
Add main menu scene

### DIFF
--- a/Scenes/MainMenu.gd
+++ b/Scenes/MainMenu.gd
@@ -1,0 +1,7 @@
+extends Control
+
+func _on_play_pressed():
+	get_tree().change_scene_to_file("res://Main.tscn")
+
+func _on_quit_pressed():
+	get_tree().quit()

--- a/Scenes/MainMenu.tscn
+++ b/Scenes/MainMenu.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=3 format=3 uid="uid://mainmenu"]
+
+[ext_resource type="Script" path="res://Scenes/MainMenu.gd" id="1"]
+
+[node name="MainMenu" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = -50.0
+offset_right = 100.0
+offset_bottom = 50.0
+
+[node name="PlayButton" type="Button" parent="VBoxContainer"]
+text = "Play"
+
+[node name="QuitButton" type="Button" parent="VBoxContainer"]
+text = "Quit"
+
+[connection signal="pressed" from="PlayButton" to="." method="_on_play_pressed"]
+[connection signal="pressed" from="QuitButton" to="." method="_on_quit_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="TCGGame"
-run/main_scene="res://Main.tscn"
+run/main_scene="res://Scenes/MainMenu.tscn"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
## Summary
- add new main menu scene with Play/Quit buttons
- hook up buttons to start the game or exit
- set the project main scene to the new menu

## Testing
- `godot --version`
- `godot --headless -q` *(fails: process hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68716b57af448329b41d0b11a64ba2a5