### PR TITLE
Add turn tracker system

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -1,7 +1,22 @@
 extends Node2D
 
 var battlefield_scene := preload("res://Scenes/Battlefield.tscn")
+const TurnTracker = preload("res://TurnTracker.gd")
+
+var turn_tracker: TurnTracker
 
 func _ready():
-	var battlefield = battlefield_scene.instantiate()
-	add_child(battlefield)
+    var battlefield = battlefield_scene.instantiate()
+    add_child(battlefield)
+
+    turn_tracker = TurnTracker.new()
+    add_child(turn_tracker)
+    turn_tracker.connect("turn_changed", _on_turn_changed)
+    _on_turn_changed(turn_tracker.current_player)
+
+func _input(event):
+    if event.is_action_pressed("ui_accept"):
+        turn_tracker.next_turn()
+
+func _on_turn_changed(player):
+    print("Player %d's turn" % (player + 1))

--- a/TurnTracker.gd
+++ b/TurnTracker.gd
@@ -1,0 +1,14 @@
+extends Node
+class_name TurnTracker
+
+signal turn_changed(current_player: int)
+
+@export var num_players: int = 2
+var current_player: int = 0
+
+func _ready():
+    emit_signal("turn_changed", current_player)
+
+func next_turn():
+    current_player = (current_player + 1) % num_players
+    emit_signal("turn_changed", current_player)


### PR DESCRIPTION
## Summary
- create `TurnTracker.gd` as a reusable node for cycling player turns
- add use of `TurnTracker` in `Main.gd`

## Testing
- `godot --version`
- `godot --headless -q --quit`

------
https://chatgpt.com/codex/tasks/task_e_68716bbba490832993c470c6a07b87ad