### PR TITLE
Load battlefield from MainMenu

### DIFF
--- a/Scenes/MainMenu.gd
+++ b/Scenes/MainMenu.gd
@@ -1,7 +1,7 @@
 extends Control
 
 func _on_play_pressed():
-	get_tree().change_scene_to_file("res://Main.tscn")
+        get_tree().change_scene_to_file("res://Scenes/Battlefield.tscn")
 
 func _on_quit_pressed():
-	get_tree().quit()
+        get_tree().quit()


### PR DESCRIPTION
## Summary
- link Play button to Battlefield scene instead of Main.tscn

## Testing
- `godot --headless --check-only -s Scenes/MainMenu.gd`


------
https://chatgpt.com/codex/tasks/task_e_68716da91068832983e9f0cfa0de9a57