### PR TITLE
Add resource bars

### DIFF
--- a/Scenes/Battlefield.gd
+++ b/Scenes/Battlefield.gd
@@ -13,6 +13,20 @@ var tiles: Array = []
 var selected_cell: Vector2i = Vector2i(-1, -1)
 
 @onready var build_menu := $BuildMenu
+@onready var player_wood_label := $PlayerResources/PlayerWood
+@onready var player_gold_label := $PlayerResources/PlayerGold
+@onready var opponent_wood_label := $OpponentResources/OpponentWood
+@onready var opponent_gold_label := $OpponentResources/OpponentGold
+
+var player_resources := {
+    "Wood": 0,
+    "Gold": 0,
+}
+
+var opponent_resources := {
+    "Wood": 0,
+    "Gold": 0,
+}
 
 func _ready():
     queue_redraw()
@@ -23,6 +37,7 @@ func _ready():
     for name in tile_scenes.keys():
         build_menu.add_item(name)
     build_menu.connect("id_pressed", _on_build_menu_id_pressed)
+    _update_resource_labels()
 
 func _draw():
     var width = grid_size.x
@@ -59,3 +74,9 @@ func _on_build_menu_id_pressed(id):
     add_child(tile)
     tile.position = Vector2(selected_cell.x, selected_cell.y) * cell_size
     tiles[selected_cell.y][selected_cell.x] = tile
+
+func _update_resource_labels():
+    player_wood_label.text = "Wood: %d" % player_resources["Wood"]
+    player_gold_label.text = "Gold: %d" % player_resources["Gold"]
+    opponent_wood_label.text = "Wood: %d" % opponent_resources["Wood"]
+    opponent_gold_label.text = "Gold: %d" % opponent_resources["Gold"]

--- a/Scenes/Battlefield.tscn
+++ b/Scenes/Battlefield.tscn
@@ -6,3 +6,33 @@
 script = ExtResource(1)
 
 [node name="BuildMenu" type="PopupMenu" parent="."]
+
+[node name="OpponentResources" type="HBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 30.0
+
+[node name="OpponentWood" type="Label" parent="OpponentResources"]
+text = "Wood: 0"
+
+[node name="OpponentGold" type="Label" parent="OpponentResources"]
+text = "Gold: 0"
+
+[node name="PlayerResources" type="HBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = -30.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="PlayerWood" type="Label" parent="PlayerResources"]
+text = "Wood: 0"
+
+[node name="PlayerGold" type="Label" parent="PlayerResources"]
+text = "Gold: 0"


### PR DESCRIPTION
## Summary
- add UI elements for opponent and player resources in `Battlefield.tscn`
- track and display wood and gold amounts in `Battlefield.gd`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871704e80d08329b8a027537ce19921