### PR TITLE
Enable right-click camera drag

### DIFF
--- a/Scenes/Battlefield.gd
+++ b/Scenes/Battlefield.gd
@@ -14,6 +14,20 @@ var selected_cell: Vector2i = Vector2i(-1, -1)
 
 @onready var build_menu := $BuildMenu
 @onready var camera := $Camera2D
+@onready var player_wood_label := $PlayerResources/PlayerWood
+@onready var player_gold_label := $PlayerResources/PlayerGold
+@onready var opponent_wood_label := $OpponentResources/OpponentWood
+@onready var opponent_gold_label := $OpponentResources/OpponentGold
+
+var player_resources := {
+    "Wood": 0,
+    "Gold": 0,
+}
+
+var opponent_resources := {
+    "Wood": 0,
+    "Gold": 0,
+}
 
 var dragging := false
 var last_mouse_pos := Vector2.ZERO
@@ -27,6 +41,12 @@ func _ready():
     for name in tile_scenes.keys():
         build_menu.add_item(name)
     build_menu.connect("id_pressed", _on_build_menu_id_pressed)
+    _update_resource_labels()
+
+    # Center the battlefield within the viewport
+    var viewport_size = get_viewport_rect().size
+    var grid_pixel_size = Vector2(grid_size) * cell_size
+    position = (viewport_size - grid_pixel_size) / 2
 
 func _draw():
     var width = grid_size.x
@@ -46,7 +66,7 @@ func _draw():
 func _input(event):
     if event is InputEventMouseButton:
         if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-            var pos = event.position
+            var pos = to_local(event.position)
             var cell = Vector2i(int(pos.x / cell_size.x), int(pos.y / cell_size.y))
             if cell.x < 0 or cell.y < 0 or cell.x >= grid_size.x or cell.y >= grid_size.y:
                 return
@@ -73,3 +93,8 @@ func _on_build_menu_id_pressed(id):
     tile.position = Vector2(selected_cell.x, selected_cell.y) * cell_size
     tiles[selected_cell.y][selected_cell.x] = tile
 
+func _update_resource_labels():
+    player_wood_label.text = "Wood: %d" % player_resources["Wood"]
+    player_gold_label.text = "Gold: %d" % player_resources["Gold"]
+    opponent_wood_label.text = "Wood: %d" % opponent_resources["Wood"]
+    opponent_gold_label.text = "Gold: %d" % opponent_resources["Gold"]

--- a/Scenes/Battlefield.gd
+++ b/Scenes/Battlefield.gd
@@ -13,6 +13,10 @@ var tiles: Array = []
 var selected_cell: Vector2i = Vector2i(-1, -1)
 
 @onready var build_menu := $BuildMenu
+@onready var camera := $Camera2D
+
+var dragging := false
+var last_mouse_pos := Vector2.ZERO
 
 func _ready():
     queue_redraw()
@@ -40,15 +44,24 @@ func _draw():
         draw_line(start, end, color)
 
 func _input(event):
-    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-        var pos = event.position
-        var cell = Vector2i(int(pos.x / cell_size.x), int(pos.y / cell_size.y))
-        if cell.x < 0 or cell.y < 0 or cell.x >= grid_size.x or cell.y >= grid_size.y:
-            return
-        if tiles[cell.y][cell.x] == null:
-            selected_cell = cell
-            build_menu.position = pos
-            build_menu.popup()
+    if event is InputEventMouseButton:
+        if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+            var pos = event.position
+            var cell = Vector2i(int(pos.x / cell_size.x), int(pos.y / cell_size.y))
+            if cell.x < 0 or cell.y < 0 or cell.x >= grid_size.x or cell.y >= grid_size.y:
+                return
+            if tiles[cell.y][cell.x] == null:
+                selected_cell = cell
+                build_menu.position = pos
+                build_menu.popup()
+        elif event.button_index == MOUSE_BUTTON_RIGHT:
+            dragging = event.pressed
+            if dragging:
+                last_mouse_pos = event.position
+    elif event is InputEventMouseMotion and dragging:
+        var delta = event.position - last_mouse_pos
+        camera.position -= delta
+        last_mouse_pos = event.position
 
 func _on_build_menu_id_pressed(id):
     var name = build_menu.get_item_text(id)
@@ -59,3 +72,4 @@ func _on_build_menu_id_pressed(id):
     add_child(tile)
     tile.position = Vector2(selected_cell.x, selected_cell.y) * cell_size
     tiles[selected_cell.y][selected_cell.x] = tile
+

--- a/Scenes/Battlefield.tscn
+++ b/Scenes/Battlefield.tscn
@@ -10,3 +10,33 @@ script = ExtResource(1)
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true
 
+[node name="OpponentResources" type="HBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 0.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 30.0
+
+[node name="OpponentWood" type="Label" parent="OpponentResources"]
+text = "Wood: 0"
+
+[node name="OpponentGold" type="Label" parent="OpponentResources"]
+text = "Gold: 0"
+
+[node name="PlayerResources" type="HBoxContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = -30.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="PlayerWood" type="Label" parent="PlayerResources"]
+text = "Wood: 0"
+
+[node name="PlayerGold" type="Label" parent="PlayerResources"]
+text = "Gold: 0"
+

--- a/Scenes/Battlefield.tscn
+++ b/Scenes/Battlefield.tscn
@@ -6,3 +6,7 @@
 script = ExtResource(1)
 
 [node name="BuildMenu" type="PopupMenu" parent="."]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+


### PR DESCRIPTION
## Summary
- add a `Camera2D` node to the battlefield scene
- allow dragging with the right mouse button to pan the camera

## Testing
- `godot --version`

------
https://chatgpt.com/codex/tasks/task_e_687171626d2083299decc57f8d7a0939