### PR TITLE
Show current turn in UI

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -4,6 +4,7 @@ var battlefield_scene := preload("res://Scenes/Battlefield.tscn")
 const TurnTracker = preload("res://TurnTracker.gd")
 
 var turn_tracker: TurnTracker
+@onready var turn_label := $TurnLabel
 
 func _ready():
 	var battlefield = battlefield_scene.instantiate()
@@ -19,4 +20,7 @@ func _input(event):
 		turn_tracker.next_turn()
 
 func _on_turn_changed(player):
-	print("Player %d's turn" % (player + 1))
+        var text = "Player %d's turn" % (player + 1)
+        print(text)
+        if is_instance_valid(turn_label):
+                turn_label.text = text

--- a/Main.tscn
+++ b/Main.tscn
@@ -4,3 +4,7 @@
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_glv2v")
+
+[node name="TurnLabel" type="Label" parent="."]
+position = Vector2(10, 10)
+text = ""


### PR DESCRIPTION
## Summary
- add a TurnLabel node to `Main.tscn`
- expose `TurnLabel` in `Main.gd` and update the label text when the turn changes

## Testing
- `godot --version`
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687171919c008329ae18bfb1a7d1833f